### PR TITLE
Update status bar on nametable hover

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -85,6 +85,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // Connect to tileset signals
     connect(ui->tileSet, SIGNAL(setStatus(QString)), this, SLOT(setStatus(QString)));
+    connect(ui->nameTable, SIGNAL(setStatus(QString)), this, SLOT(setStatus(QString)));
 
     // Create one nametable
     mNameTables.append(ui->nameTable);

--- a/src/nametable.cpp
+++ b/src/nametable.cpp
@@ -50,10 +50,29 @@ NameTable::NameTable(QWidget *parent) :
 
     mAttrs = &mData[960];
 
+    int NAMETABLES [4] = { 8192, 9216, 10240, 11264 };
+    int ATTRTABLES [4] = { 9152, 10176, 11200, 12224 };
+
     for (int i = 0; i < 30; ++i) {
         for (int j = 0; j < 32; ++j) {
+            int nameOffset = i*32 + j;
+            int attrOffset = (j - (j % 4)) / 4;
+            attrOffset += ((i - (i % 4)) / 4) * 8;
             Tile *tile = new Tile(this);
+
             tile->setFixedSize(QSize(24, 24));
+            tile->setHoverText(QString("Nametable offset: $%1 ($%2, $%3, $%4, $%5)     Attribute offset: $%6 ($%7, $%8, $%9, $%10)")
+                .arg(nameOffset, 4, 16, QChar('0'))
+                .arg(NAMETABLES[0] + nameOffset, 4, 16, QChar('0'))
+                .arg(NAMETABLES[1] + nameOffset, 4, 16, QChar('0'))
+                .arg(NAMETABLES[2] + nameOffset, 4, 16, QChar('0'))
+                .arg(NAMETABLES[3] + nameOffset, 4, 16, QChar('0'))
+                .arg(attrOffset, 2, 16, QChar('0'))
+                .arg(ATTRTABLES[0] + attrOffset, 4, 16, QChar('0'))
+                .arg(ATTRTABLES[1] + attrOffset, 4, 16, QChar('0'))
+                .arg(ATTRTABLES[2] + attrOffset, 4, 16, QChar('0'))
+                .arg(ATTRTABLES[3] + attrOffset, 4, 16, QChar('0')));
+            connect(tile, SIGNAL(hovered()), this, SLOT(tileHovered()));
             mTiles.append(tile);
             mGridLayout->addWidget(tile, i, j);
         }
@@ -479,4 +498,10 @@ void NameTable::mouseMoveEvent(QMouseEvent *event)
             emit tileClicked(index %32, index / 32);
         }
     }
+}
+
+void NameTable::tileHovered()
+{
+  Tile *tile = qobject_cast<Tile*>(sender());
+  emit setStatus(tile->getHoverText());
 }

--- a/src/nametable.h
+++ b/src/nametable.h
@@ -83,11 +83,13 @@ protected:
 
 Q_SIGNALS:
     void tileClicked(int x, int y);
+    void setStatus(QString text); // change status bar message
 
 private Q_SLOTS:
     void tileClicked();
     void paletteChanged();
     void tilesChanged();
+    void tileHovered();
 
 private:
     // Get the palette for a given tile

--- a/src/tileset.cpp
+++ b/src/tileset.cpp
@@ -28,6 +28,7 @@
 #include <QRadioButton>
 #include <QSettings>
 #include <QToolButton>
+#include <QRubberBand>
 
 #include "defines.h"
 #include "edittiledialog.h"


### PR DESCRIPTION
When hovering over a nametable tile, the status bar updates to show the nametable and attribute table offsets as well as the specific addresses for all four nametables / attribute tables.

I'm sure there's probably a "cleaner" way to set up the code for this, but I went for what I felt would be most readable. Let me know if you have any suggestions!